### PR TITLE
Adding the basis of the action

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = tab
+indent_size = 4
+
+[*.{ts,tsx,js,jsx,scss,css,json,yaml,yml,feature,xml}]
+indent_style = space
+indent_size = 2
+
+# Composer File
+[composer.{json,lock}]
+indent_style = space
+indent_size = 4
+
+# Dotfiles
+[.*]
+indent_style = space
+indent_size = 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Automated Tests
+
+on:
+  pull_request:
+    branches:
+      - develop
+  push:
+    branches:
+      - develop
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Shellcheck
+      uses: ludeeus/action-shellcheck@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Build files
+build
+vendor
+composer.lock
+node_modules
+
+# Log files
+*.log
+
+# Cache files
+.phpcs/*.json
+.phpunit.result.cache
+
+# Ignore temporary OS files
+.DS_Store
+.DS_Store?
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+.thumbsdb
+
+# IDE files
+*.code-workspace
+.idea
+.vscode

--- a/README.md
+++ b/README.md
@@ -18,15 +18,17 @@ the name of the file using the `plugin-file` input.
 
 ```yaml
 name: Update WordPress Plugin
+
 on:
   schedule:
     - cron: '0 0 * * *'
+
 jobs:
   update-plugin:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: alleyinteractive/action-update-wordpress-plugin@develop
+    - uses: actions/checkout@v3
+    - uses: alleyinteractive/action-update-wordpress-plugin@feature
       with:
         plugin-file: 'plugin.php'
         upgrade-npm-dependencies: "true"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# Update WordPress Plugin Action
+
+Automatically update your
+[alleyinteractive/create-wordpress-plugin](https://github.com/alleyinteractive/create-wordpress-plugin)-based
+plugins to the latest WordPress version whenever core releases a new version.
+
+When a new version of WordPress is released, this action will automatically bump
+the `Tested up to` version of the plugin. You can also run the [`packages-update`
+npm
+script](https://github.com/alleyinteractive/create-wordpress-plugin#updating-wp-dependencies)
+to update the WordPress plugin dependencies to match the latest WordPress version.
+
+### Usage
+
+By default, the plugin will look for a `plugin.php` file in the root of the
+repository. If your plugin's main file is named something else, you can specify
+the name of the file using the `plugin-file` input.
+
+```yaml
+name: Update WordPress Plugin
+on:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  update-plugin:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: alleyinteractive/action-update-wordpress-plugin@develop
+      with:
+        plugin-file: 'plugin.php'
+        upgrade-npm-dependencies: "true"
+```
+
+### Changelog
+
+#### 1.0.0
+
+- Initial release.
+
+## Credits
+
+This project is actively maintained by [Alley
+Interactive](https://github.com/alleyinteractive). Like what you see? [Come work
+with us](https://alley.com/careers/).
+
+- [Sean Fisher](https://github.com/srtfisher)
+- [All Contributors](../../contributors)
+
+## License
+
+The GNU General Public License (GPL) license. Please see [License File](LICENSE) for more information.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ npm
 script](https://github.com/alleyinteractive/create-wordpress-plugin#updating-wp-dependencies)
 to update the WordPress plugin dependencies to match the latest WordPress version.
 
-### Usage
+## Usage
 
 By default, the plugin will look for a `plugin.php` file in the root of the
 repository. If your plugin's main file is named something else, you can specify
@@ -20,8 +20,13 @@ the name of the file using the `plugin-file` input.
 name: Update WordPress Plugin
 
 on:
+  pull_request:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 */6 * * *'
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   update-plugin:
@@ -32,11 +37,21 @@ jobs:
       with:
         plugin-file: 'plugin.php'
         upgrade-npm-dependencies: "true"
+
 ```
 
-### Changelog
+The action assumes that a `package-lock.json` file exists in the root of the
+repository to run `npm ci`.
 
-#### 1.0.0
+### Inputs
+
+- `plugin-file` - The name of the plugin's main file. Defaults to `plugin.php`.
+- `upgrade-npm-dependencies` - Whether or not to run the `packages-update` npm
+  script. Defaults to `"true"`. Set to `"false"` to disable.
+
+## Changelog
+
+### 1.0.0
 
 - Initial release.
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,29 @@
+name: 'Update WordPress Plugin'
+description: 'Update your create-wordpress-plugin based plugin with the latest dependencies when a new core version is released'
+author: 'alleyinteractive'
+branding:
+  color: 'orange'
+  icon: 'refresh-ccw'
+inputs:
+  plugin-file:
+    description: 'The main file for the plugin'
+    default: "plugin.php"
+    required: false
+  upgrade-npm-dependencies:
+    description: 'Upgrade the npm dependencies of the plugin to match WordPress'
+    default: "true"
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - id: setup-node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+        cache: 'npm'
+    - id: check-upgrade
+      env:
+        PLUGIN_FILE: ${{ inputs.plugin-file }}
+        UPGRADE_DEPENDENCIES: ${{ inputs.upgrade-npm-dependencies }}
+      run: ${{ github.action_path }}/check-upgrade.sh
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ runs:
       env:
         PLUGIN_FILE: ${{ inputs.plugin-file }}
         UPGRADE_DEPENDENCIES: ${{ inputs.upgrade-npm-dependencies }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ github.token }}
       run: ${{ github.action_path }}/check-upgrade.sh
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -25,5 +25,6 @@ runs:
       env:
         PLUGIN_FILE: ${{ inputs.plugin-file }}
         UPGRADE_DEPENDENCIES: ${{ inputs.upgrade-npm-dependencies }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: ${{ github.action_path }}/check-upgrade.sh
       shell: bash

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -81,7 +81,7 @@ git add -A && git commit -m "Upgrade plugin to $WP_VERSION"
 git push origin "$BRANCH_NAME"
 
 # Create a pull request.
-gh pr create --title "Upgrade plugin to WordPress $WP_VERSION" --body "Upgrade plugin to \`$WP_VERSION\`" --head "$BRANCH_NAME"
+gh pr create --title "Upgrade plugin to WordPress $WP_VERSION" --body "- [ ] Test plugin against WordPress \`$WP_VERSION\`" --head "$BRANCH_NAME"
 
 echo "[action-update-wordpress-plugin] Pull request created"
 exit 0

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -54,8 +54,9 @@ echo "[action-update-wordpress-plugin] Upgrading plugin to $WP_VERSION ..."
 
 set -e
 
-# Checkout a new branch.
-git checkout -b "action/upgrade-to-$WP_VERSION"
+# Checkout a new branch including the current time
+BRANCH_NAME="action/upgrade-to-$WP_VERSION-$(date +%s)"
+git checkout -b "$BRANCH"
 
 # npm ci if UPGRADE_DEPENDENCIES is not equal to "false".
 if [ "$UPGRADE_DEPENDENCIES" != "false" ]; then
@@ -76,10 +77,10 @@ git config --global user.name "$GITHUB_ACTOR"
 
 # Commit all the changes.
 git add -A && git commit -m "Upgrade plugin to $WP_VERSION"
-git push origin "action/upgrade-to-$WP_VERSION"
+git push origin "$BRANCH_NAME"
 
 # Create a pull request.
-gh pr create --title "Upgrade plugin to $WP_VERSION" --body "Upgrade plugin to $WP_VERSION" --head "action/upgrade-to-$WP_VERSION"
+gh pr create --title "Upgrade plugin to $WP_VERSION" --body "Upgrade plugin to \`$WP_VERSION\`" --head "$BRANCH_NAME"
 
 echo "[action-update-wordpress-plugin] Pull request created"
 exit 0

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -46,7 +46,7 @@ if [ "$(echo "$LATEST_VERSION" | sed 's/\.//g')" -gt "$(echo "$WP_VERSION" | sed
 fi
 
 # Check if a pull request already exists with the gh cli.
-if [ "$(gh pr list --search "Upgrade plugin to WordPress $WP_VERSION" | wc -l)" -gt 0 ]; then
+if [ "$(gh pr list --search "Upgrade plugin to WordPress $WP_VERSION" --state "all" | wc -l)" -gt 0 ]; then
 	echo "[action-update-wordpress-plugin] Pull request already exists, no upgrade needed."
 	exit 0
 fi

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+# Automatically upgrade a plugin to match the latest WordPress version.
+
+# Ensure PLUGIN_FILE is set.
+if [ -z "$PLUGIN_FILE" ]; then
+	echo "PLUGIN_FILE is not set."
+	exit 1
+fi
+
+# Check if PLUGIN_FILE exists.
+if [ ! -f "$PLUGIN_FILE" ]; then
+	echo "$PLUGIN_FILE does not exist."
+	exit 1
+fi
+
+# Extract the latest version from the plugin file.
+LATEST_VERSION=$(grep "Tested up to:" "$PLUGIN_FILE" | awk '{print $NF}')
+
+# Ensure latest version is always in x.x.x format (e.g. 5.2.1 vs 5.2).
+LATEST_VERSION=$(echo "$LATEST_VERSION" | awk -F. '{printf("%d.%d.%d\n", $1,$2,$3)}')
+
+# Check if the latest version is set and not empty.
+if [ -z "$LATEST_VERSION" ]; then
+	echo "Latest version is not set."
+	exit 1
+fi
+
+# Fetch the latest WordPress version from api.wordpress.org.
+WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
+
+# Early exist if they're the same version.
+if [ "$WP_VERSION" == "$LATEST_VERSION" ]; then
+	echo "Latest WordPress version and plugin-supported version are the same, no upgrade needed."
+	exit 0
+fi
+
+echo "Latest WordPress version:        $WP_VERSION"
+echo "Latest plugin supported version: $LATEST_VERSION"
+
+# Check if the latest plugin version is less than the latest WordPress version.
+if [ "$(echo "$LATEST_VERSION" | sed 's/\.//g')" -gt "$(echo "$WP_VERSION" | sed 's/\.//g')" ]; then
+	echo "Plugin is already up-to-date, no upgrade needed."
+	exit 0
+fi
+
+# Check if a pull request already exists with the gh cli.
+if [ "$(gh pr list --search "Upgrade plugin to $WP_VERSION" | wc -l)" -gt 0 ]; then
+	echo "Pull request already exists, no upgrade needed."
+	exit 0
+fi
+
+echo "Upgrading plugin to $WP_VERSION ..."
+
+set -e
+
+# Checkout a new branch.
+git checkout -b "action/upgrade-to-$WP_VERSION"
+
+# npm ci if UPGRADE_DEPENDENCIES is not equal to "false".
+if [ "$UPGRADE_DEPENDENCIES" != "false" ]; then
+	npm ci
+
+	# Run the "npm run packages-update" command.
+	npm run packages-update --dist-tag=wp-$WP_VERSION
+else
+	echo "Skipping dependency upgrade."
+fi
+
+# Replace the 'Tested up to' version in the plugin file.
+sed -i "" "s/Tested up to: .*/Tested up to: $WP_VERSION/g" plugin.php
+
+exit 0
+
+# Commit all the changes.
+git add .
+git commit -m "Upgrade plugin to $WP_VERSION"
+git push origin "action/upgrade-to-$WP_VERSION"
+
+# Create a pull request.
+gh pr create --title "Upgrade plugin to $WP_VERSION" --body "Upgrade plugin to $WP_VERSION" --head "action/upgrade-to-$WP_VERSION"
+
+echo "Pull request created."

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -39,6 +39,7 @@ echo "[action-update-wordpress-plugin] Latest WordPress version:        $WP_VERS
 echo "[action-update-wordpress-plugin] Latest plugin supported version: $LATEST_VERSION"
 
 # Check if the latest plugin version is less than the latest WordPress version.
+# shellcheck disable=SC2001
 if [ "$(echo "$LATEST_VERSION" | sed 's/\.//g')" -gt "$(echo "$WP_VERSION" | sed 's/\.//g')" ]; then
 	echo "[action-update-wordpress-plugin] Plugin is already up-to-date, no upgrade needed."
 	exit 0
@@ -63,13 +64,13 @@ if [ "$UPGRADE_DEPENDENCIES" != "false" ]; then
 	npm ci
 
 	# Run the "npm run packages-update" command.
-	npm run packages-update --dist-tag=wp-$WP_VERSION
+	npm run packages-update --dist-tag="wp-$WP_VERSION"
 else
 	echo "[action-update-wordpress-plugin] Skipping dependency upgrade."
 fi
 
 # Replace the 'Tested up to' version in the plugin file.
-sed -i "s/Tested up to: .*/Tested up to: $WP_VERSION/g" $PLUGIN_FILE
+sed -i "s/Tested up to: .*/Tested up to: $WP_VERSION/g" "$PLUGIN_FILE"
 
 # Setup Git.
 git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -45,7 +45,7 @@ if [ "$(echo "$LATEST_VERSION" | sed 's/\.//g')" -gt "$(echo "$WP_VERSION" | sed
 fi
 
 # Check if a pull request already exists with the gh cli.
-if [ "$(gh pr list --search "Upgrade plugin to $WP_VERSION" | wc -l)" -gt 0 ]; then
+if [ "$(gh pr list --search "Upgrade plugin to WordPress $WP_VERSION" | wc -l)" -gt 0 ]; then
 	echo "[action-update-wordpress-plugin] Pull request already exists, no upgrade needed."
 	exit 0
 fi
@@ -80,7 +80,7 @@ git add -A && git commit -m "Upgrade plugin to $WP_VERSION"
 git push origin "$BRANCH_NAME"
 
 # Create a pull request.
-gh pr create --title "Upgrade plugin to $WP_VERSION" --body "Upgrade plugin to \`$WP_VERSION\`" --head "$BRANCH_NAME"
+gh pr create --title "Upgrade plugin to WordPress $WP_VERSION" --body "Upgrade plugin to \`$WP_VERSION\`" --head "$BRANCH_NAME"
 
 echo "[action-update-wordpress-plugin] Pull request created"
 exit 0

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -56,7 +56,7 @@ set -e
 
 # Checkout a new branch including the current time
 BRANCH_NAME="action/upgrade-to-$WP_VERSION-$(date +%s)"
-git checkout -b "$BRANCH"
+git checkout -b "$BRANCH_NAME"
 
 # npm ci if UPGRADE_DEPENDENCIES is not equal to "false".
 if [ "$UPGRADE_DEPENDENCIES" != "false" ]; then

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -68,7 +68,7 @@ else
 fi
 
 # Replace the 'Tested up to' version in the plugin file.
-sed -i "" "s/Tested up to: .*/Tested up to: $WP_VERSION/g" $PLUGIN_FILE
+sed -i "s/Tested up to: .*/Tested up to: $WP_VERSION/g" $PLUGIN_FILE
 
 # Commit all the changes.
 git add .

--- a/check-upgrade.sh
+++ b/check-upgrade.sh
@@ -70,9 +70,12 @@ fi
 # Replace the 'Tested up to' version in the plugin file.
 sed -i "s/Tested up to: .*/Tested up to: $WP_VERSION/g" $PLUGIN_FILE
 
+# Setup Git.
+git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
+git config --global user.name "$GITHUB_ACTOR"
+
 # Commit all the changes.
-git add .
-git commit -m "Upgrade plugin to $WP_VERSION"
+git add -A && git commit -m "Upgrade plugin to $WP_VERSION"
 git push origin "action/upgrade-to-$WP_VERSION"
 
 # Create a pull request.


### PR DESCRIPTION
Introduces an action that creates a pull request on plugin repositories when a new WordPress version is released.

Example: https://github.com/alleyinteractive/create-wordpress-plugin/pull/95

Will be run at least once per day.