### PR TITLE
Issue-9: Allow node version to be specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ jobs:
       with:
         plugin-file: 'plugin.php'
         upgrade-npm-dependencies: "true"
+        node-version: '20'  # Specify the Node.js version if not lts
+
 
 ```
 
@@ -48,8 +50,14 @@ repository to run `npm ci`.
 - `plugin-file` - The name of the plugin's main file. Defaults to `plugin.php`.
 - `upgrade-npm-dependencies` - Whether or not to run the `packages-update` npm
   script. Defaults to `"true"`. Set to `"false"` to disable.
+- `node-version` - The version of Node.js to use for running the action. Defaults to `"lts"`. Specify any version number or tag supported by actions/setup-node@v3 (e.g., `18`, `20`, `lts`, `latest`, etc.).
+
 
 ## Changelog
+
+### 1.2.2
+
+- Update action to allow node-version input (defaults to `lts`).
 
 ### 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ repository to run `npm ci`.
 
 ## Changelog
 
-### 1.2.2
+### 2.0.0
 
-- Update action to allow node-version input (defaults to `lts`).
+- Update action to allow node-version input (defaults to `lts`). *This is a breaking change*, as the action previously used Node.js 16.x.
 
 ### 1.2.1
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ jobs:
         upgrade-npm-dependencies: "true"
         node-version: '20'  # Specify the Node.js version if not lts
 
-
 ```
 
 The action assumes that a `package-lock.json` file exists in the root of the

--- a/action.yml
+++ b/action.yml
@@ -13,13 +13,17 @@ inputs:
     description: 'Upgrade the npm dependencies of the plugin to match WordPress'
     default: "true"
     required: false
+  node-version:
+    description: 'The version of Node.js to use'
+    default: "lts"
+    required: false
 runs:
   using: 'composite'
   steps:
     - id: setup-node
       uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: ${{ inputs.node-version }}
     - id: check-upgrade
       env:
         PLUGIN_FILE: ${{ inputs.plugin-file }}


### PR DESCRIPTION
## Summary
This PR allows the specification of a node version when running the action, providing flexibility for projects that use different versions of node. Fixes #9

## Changes
- Support for `node-version` input has been introduced to allow for more detailed configuration (default the node version to `lts` if it is not specified).

## Test Plan
- Verify that specifying a node version correctly sets that version for the action.
- Ensure that not specifying a node version defaults to `lts`.

## Related Issues
- [#9](https://github.com/alleyinteractive/action-update-wordpress-plugin/issues/9)