### PR TITLE
Issue-11: Workflow failure due to incorrect node version syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,14 @@ repository to run `npm ci`.
 - `plugin-file` - The name of the plugin's main file. Defaults to `plugin.php`.
 - `upgrade-npm-dependencies` - Whether or not to run the `packages-update` npm
   script. Defaults to `"true"`. Set to `"false"` to disable.
-- `node-version` - The version of Node.js to use for running the action. Defaults to `"lts"`. Specify any version number or tag supported by actions/setup-node@v3 (e.g., `18`, `20`, `lts`, `latest`, etc.).
+- `node-version` - The version of Node.js to use for running the action. Defaults to `"lts/*"`. Specify any version number or tag supported by actions/setup-node@v3 (e.g., `18`, `20`, `lts/*`, `latest`, etc.).
 
 
 ## Changelog
+
+### 2.0.1
+
+- Fixes default node version in action from `lts` to `lts/*`, which is the syntax expected by the `setup-node` action.
 
 ### 2.0.0
 

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: false
   node-version:
     description: 'The version of Node.js to use'
-    default: "lts"
+    default: "lts/*"
     required: false
 runs:
   using: 'composite'


### PR DESCRIPTION
## Summary
This PR fixes an issue where `create-wordpress-plugin` based plugins, which utilize this action, were failing due to the invalid `default` `node-version`. Fixes #11

## Related Issues
- [#11](https://github.com/alleyinteractive/action-update-wordpress-plugin/issues/11)